### PR TITLE
merge package template from arlac77/npm-package-template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ before_script:
   - npm install -g --production coveralls codecov
 script:
   - npm run cover
+  - npm run lint
+  - npm run docs
 after_script:
   - codecov
   - cat ./build/coverage/lcov.info | coveralls

--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 [![npm](https://img.shields.io/npm/v/kronos-step-aggregate.svg)](https://www.npmjs.com/package/kronos-step-aggregate)
+[![Greenkeeper](https://badges.greenkeeper.io/Kronos-Integration/kronos-step-aggregate.svg)](https://greenkeeper.io/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/Kronos-Integration/kronos-step-aggregate)
+[![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 [![Build Status](https://secure.travis-ci.org/Kronos-Integration/kronos-step-aggregate.png)](http://travis-ci.org/Kronos-Integration/kronos-step-aggregate)
 [![bithound](https://www.bithound.io/github/Kronos-Integration/kronos-step-aggregate/badges/score.svg)](https://www.bithound.io/github/Kronos-Integration/kronos-step-aggregate)
 [![codecov.io](http://codecov.io/github/Kronos-Integration/kronos-step-aggregate/coverage.svg?branch=master)](http://codecov.io/github/Kronos-Integration/kronos-step-aggregate?branch=master)
-[![Code Climate](https://codeclimate.com/github/Kronos-Integration/kronos-step-aggregate/badges/gpa.svg)](https://codeclimate.com/github/Kronos-Integration/kronos-step-aggregate)
+[![Coverage Status](https://coveralls.io/repos/Kronos-Integration/kronos-step-aggregate/badge.svg)](https://coveralls.io/r/Kronos-Integration/kronos-step-aggregate)
+[![Known Vulnerabilities](https://snyk.io/test/github/Kronos-Integration/kronos-step-aggregate/badge.svg)](https://snyk.io/test/github/Kronos-Integration/kronos-step-aggregate)
 [![GitHub Issues](https://img.shields.io/github/issues/Kronos-Integration/kronos-step-aggregate.svg?style=flat-square)](https://github.com/Kronos-Integration/kronos-step-aggregate/issues)
+[![Stories in Ready](https://badge.waffle.io/Kronos-Integration/kronos-step-aggregate.svg?label=ready&title=Ready)](http://waffle.io/Kronos-Integration/kronos-step-aggregate)
 [![Dependency Status](https://david-dm.org/Kronos-Integration/kronos-step-aggregate.svg)](https://david-dm.org/Kronos-Integration/kronos-step-aggregate)
 [![devDependency Status](https://david-dm.org/Kronos-Integration/kronos-step-aggregate/dev-status.svg)](https://david-dm.org/Kronos-Integration/kronos-step-aggregate#info=devDependencies)
 [![docs](http://inch-ci.org/github/Kronos-Integration/kronos-step-aggregate.svg?branch=master)](http://inch-ci.org/github/Kronos-Integration/kronos-step-aggregate)
+[![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/sindresorhus/xo)
 [![downloads](http://img.shields.io/npm/dm/kronos-step-aggregate.svg?style=flat-square)](https://npmjs.org/package/kronos-step-aggregate)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
@@ -19,7 +24,6 @@ Dispatches a request to several endpoints and aggregates the responses into one 
 install
 =======
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/Kronos-Integration/kronos-step-aggregate.svg)](https://greenkeeper.io/)
 
 With [npm](http://npmjs.org) do:
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "pretest": "rollup -c tests/rollup.config.js",
     "posttest": "npm run prepare && markdown-doctest",
     "prepare": "rollup -c",
-    "docs": "jsdoc2md --configure doc/jsdoc.json -l off -t doc/README.hbs -f src/*.js >README.md"
+    "docs": "documentation readme src/step-aggregate.js --section=API",
+    "lint": "documentation lint src/step-aggregate.js"
   },
   "repository": {
     "type": "git",
@@ -32,16 +33,14 @@
   "devDependencies": {
     "kronos-service-manager": "^3.5.10",
     "kronos-test-step": "3.1.4",
-    "semantic-release": "^11.0.2",
-    "jsdoc-to-markdown": "^3.0.2",
-    "jsdoc-babel": "^0.3.0",
+    "semantic-release": "^11.1.0",
     "markdown-doctest": "^0.9.1",
     "nyc": "^11.4.1",
     "ava": "^0.24.0",
     "rollup": "^0.53.0",
     "rollup-plugin-multi-entry": "^2.0.2",
-    "babel-preset-env": "^1.6.1",
-    "xo": "^0.19.0"
+    "xo": "^0.19.0",
+    "documentation": "^5.3.5"
   },
   "contributors": [
     {


### PR DESCRIPTION
package.json
---
- chore(devDependencies): remove jsdoc-babel@^0.3.0
- chore(devDependencies): remove jsdoc-to-markdown@^3.0.2
- chore(devDependencies): add documentation@^5.3.5 from template
- chore(devDependencies): update semantic-release@^11.1.0 from template
- chore(scripts): update docs@documentation readme src/step-aggregate.js --section=API from template
- chore(scripts): add lint@documentation lint src/step-aggregate.js from template

.travis.yml
---
- chore(travis): merge from template .travis.yml

README.md
---
- docs(README): update from template
